### PR TITLE
refactor: 🎨 Add json structs for contextualizing STIG data

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,10 +27,10 @@ jobs:
           echo "REVISION=$REVISION" >> $GITHUB_ENV
 
       - name: Build for Ubuntu
-        run: GOOS=linux go build -o stgo-linux *.go
+        run: GOOS=linux go build -o stgo-linux -v ./...
       
       - name: Build for Mac Darwin
-        run: GOOS=darwin go build -o stgo-darwin *.go
+        run: GOOS=darwin go build -o stgo-darwin -v ./...
 
       - name: Create Release
         id: create_release

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ You can watch a demo of the program in action here:
 
 ```bash
 cd stig-viewer
-go build -o stgo ./main.go
+go build -o stgo .
 ```
 
 ## Usage

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/danfedick/stgo
+
+go 1.20

--- a/main.go
+++ b/main.go
@@ -22,7 +22,7 @@ func main() {
 		return
 	}
 
-	var data map[string]interface{}
+	var data stigData
 	var err error
 
 	if *fileFlag != "" {
@@ -36,24 +36,23 @@ func main() {
 		return
 	}
 
-	findings := data["stig"].(map[string]interface{})["findings"].(map[string]interface{})
+	findings := data.Stig.Findings
 
 	if *srgFlag != "" || *vulnFlag != "" {
 		matchingFindings := 0
 		for _, finding := range findings {
-			findingMap := finding.(map[string]interface{})
-			if (findingMap["version"].(string) == *srgFlag && *srgFlag != "") || (findingMap["id"].(string) == *vulnFlag && *vulnFlag != "") {
+			if (finding.Version == *srgFlag && *srgFlag != "") || (finding.Id == *vulnFlag && *vulnFlag != "") {
 				matchingFindings++
 				fmt.Println("")
 				fmt.Println("\033[4;36mVULN ID:\033[0m")
-				fmt.Println(findingMap["id"].(string))
+				fmt.Println(finding.Id)
 				fmt.Println("")
 				fmt.Println("\033[4;36mSRG:\033[0m")
-				fmt.Println(findingMap["version"].(string))
+				fmt.Println(finding.Version)
 				fmt.Println("")
 				fmt.Println("\033[4;36mSEVERITY:\033[0m")
 
-				severity := findingMap["severity"].(string)
+				severity := finding.Severity
 				switch severity {
 				case "high":
 					fmt.Print("\033[31m") // Red
@@ -67,10 +66,10 @@ func main() {
 				fmt.Print("\033[0m") // Reset color
 				fmt.Println("")
 				fmt.Println("\033[4;36mTITLE:\033[0m")
-				fmt.Println(findingMap["title"].(string))
+				fmt.Println(finding.Title)
 				fmt.Println("")
 				fmt.Println("\033[4;36mDESCRIPTION:\033[0m")
-				fmt.Println(findingMap["description"].(string))
+				fmt.Println(finding.Description)
 				fmt.Println("")
 			}
 		}
@@ -86,40 +85,40 @@ func main() {
 	} else {
 		fmt.Println("List of IDs:")
 		for _, finding := range findings {
-			findingMap := finding.(map[string]interface{})
-			fmt.Println(findingMap["id"].(string))
+			findingMap := finding
+			fmt.Println(findingMap.Id)
 		}
 	}
 }
 
-func readStigFromFile(file string) (map[string]interface{}, error) {
+func readStigFromFile(file string) (stigData, error) {
 	data, err := ioutil.ReadFile(file)
 	if err != nil {
-		return nil, err
+		return stigData{}, err
 	}
-	var result map[string]interface{}
+	var result stigData
 	err = json.Unmarshal(data, &result)
 	if err != nil {
-		return nil, err
+		return stigData{}, err
 	}
 	return result, nil
 }
 
-func readStigFromURL(url string) (map[string]interface{}, error) {
+func readStigFromURL(url string) (stigData, error) {
 	resp, err := http.Get(url)
 	if err != nil {
-		return nil, err
+		return stigData{}, err
 	}
 	defer resp.Body.Close()
 
 	data, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return nil, err
+		return stigData{}, err
 	}
-	var result map[string]interface{}
+	var result stigData
 	err = json.Unmarshal(data, &result)
 	if err != nil {
-		return nil, err
+		return stigData{}, err
 	}
 	return result, nil
 }

--- a/stigs.go
+++ b/stigs.go
@@ -1,0 +1,21 @@
+package main
+
+type stigData struct {
+	Stig struct {
+		Findings map[string]stigFindings `json:"findings"`
+	} `json:"stig"`
+}
+
+type stigFindings struct {
+	CheckId     string      `json:"checkid"`
+	CheckText   string      `json:"checktext"`
+	Description string      `json:"description"`
+	FixId       string      `json:"fixid"`
+	FixText     string      `json:"fixtext"`
+	IaControls  interface{} `json:"iacontrols"`
+	Id          string      `json:"id"`
+	RuleID      string      `json:"ruleID"`
+	Severity    string      `json:"severity"`
+	Title       string      `json:"title"`
+	Version     string      `json:"version"`
+}


### PR DESCRIPTION
Two changes in this PR:

1. Addition of the go.mod file for packaging, SBOM, etc.
2. JSON structs for creating "hard addresses" for data Unmarshal'd

While this is not a feature enhancement change, it will prove useful by enabling data interaction in clearer ways for devs.

Note: leaving this PR in Draft mode until the merge checks come back green on the build action.