### PR TITLE
ci: :construction_worker: Separate build and release jobs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,6 +38,7 @@ jobs:
           path: ./stgo-darwin
           
   release:
+    needs: [build]
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,16 +21,37 @@ jobs:
         with:
           go-version: 1.19
 
-      - name: Set revision environment variable
-        run: |
-          REVISION=$(git rev-parse --short HEAD)
-          echo "REVISION=$REVISION" >> $GITHUB_ENV
-
       - name: Build for Ubuntu
         run: GOOS=linux go build -o stgo-linux *.go
       
       - name: Build for Mac Darwin
         run: GOOS=darwin go build -o stgo-darwin *.go
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: linux-build
+          path: ./stgo-linux
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: darwin-build
+          path: ./stgo-darwin
+          
+  release:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          name: linux-build
+      - uses: actions/download-artifact@v2
+        with:
+          name: darwin-build
+
+      - name: Set revision environment variable
+        run: |
+          REVISION=$(git rev-parse --short HEAD)
+          echo "REVISION=$REVISION" >> $GITHUB_ENV
 
       - name: Create Release
         id: create_release

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,7 +39,7 @@ jobs:
           
   release:
     needs: [build]
-    if: github.event_name == 'pull_request'
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v2

--- a/main.go
+++ b/main.go
@@ -92,6 +92,7 @@ func main() {
 	}
 }
 
+// Trigger actions workflow
 func readStigFromFile(file string) (map[string]interface{}, error) {
 	data, err := ioutil.ReadFile(file)
 	if err != nil {


### PR DESCRIPTION
Separation of build and release allows for the use of the 'if' clause. This enables the workflow to restrict release creation to commits on the 'main' branch.